### PR TITLE
Update launch docker options

### DIFF
--- a/docker/run-example.sh
+++ b/docker/run-example.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker run  -it da_image /bin/bash 
+docker run -it --network="host" da_image /bin/bash 


### PR DESCRIPTION
`localhost` is not recognised when executing `./run.sh --id 1 --hosts hosts --barrier localhost:11000 --output output1.out config` with docker for windows without this option. And it fails to connect to the barrier.